### PR TITLE
Update bowtie memory spec to a more accurate amount

### DIFF
--- a/workflows/tasks/bowtie.wdl
+++ b/workflows/tasks/bowtie.wdl
@@ -13,10 +13,13 @@ task bowtie {
         Int good_alignments = 2
         Boolean best_alignments = true
 
-        Int memory_gb = 10
+        Int additional_memory_gb = 10
         Int max_retries = 1
         Int ncpu = 20
     }
+
+    Int memory_gb = ceil(size(fastqfile)) + ceil(size(index_files)) + additional_memory_gb
+
     command <<<
         if [ -f "~{metricsfile}" ]; then
             readlength=$(tail -n 1 ~{metricsfile} | awk '{print $4}');
@@ -37,7 +40,7 @@ task bowtie {
             > ~{outputfile}
     >>>
     runtime {
-        memory: ceil(memory_gb * ncpu) + " GB"
+        memory: memory_gb + " GB"
         maxRetries: max_retries
         docker: 'abralab/bowtie:v1.2.3'
         cpu: ncpu


### PR DESCRIPTION
Bowtie's memory consumption is tied to the size of the input and reference data. This change reflects that, rather than allocating a certain amount per CPU. It adds a customizable (default = 10gb) additional memory buffer. On the cluster, the previous default 200gb memory request leads to excessive queue times for alignment jobs.

Here is the bowtie manual discussion of memory requirements:
> Because Bowtie uses an in-memory representation of the original reference string when finding paired-end alignments, its memory footprint is larger when aligning paired-end reads. For example, the human index has a memory footprint of about 2.2 GB in single-end mode and 2.9 GB in paired-end mode.

