### PR TITLE
Change SAM tags to lowercase to follow SAM spec.

### DIFF
--- a/workflows/tasks/peaseq_util.wdl
+++ b/workflows/tasks/peaseq_util.wdl
@@ -27,7 +27,7 @@ task fraggraph {
         ln -s ~{chromsizes} genome.chrom.sizes
 
         #namesort
-        samtools sort -t PS \
+        samtools sort -t ps \
             ~{bamfile} \
             -o ~{sub(basename(bamfile),".bam$", ".ns.bam")}
 

--- a/workflows/tasks/samtools.wdl
+++ b/workflows/tasks/samtools.wdl
@@ -86,8 +86,8 @@ task viewsort {
 
             awk -F\\t 'BEGIN{j=0}{j++}{for(i=1;i<=NF;i++){ \
                 printf "%s\t", $i}; if(NF>5 && j%2==0){ \
-                printf "PS:i:%.0f", j-1 } else if(NF>5 && j%2==1){ \
-                printf "PS:i:%.0f", j } else { j=0 } printf "\n" }' \
+                printf "ps:i:%.0f", j-1 } else if(NF>5 && j%2==1){ \
+                printf "ps:i:%.0f", j } else { j=0 } printf "\n" }' \
                 ~{samfile} > ~{basename(sub(samfile,'.sam$','.renamed.sam'))}
 
             samtools fixmate -m \


### PR DESCRIPTION
The SAM spec reserves lowercase tags for end users' usage. To comply with that standard, this PR converts the SAM tags to lowercase.