### PR TITLE
Make parameter required, since it has a default

### DIFF
--- a/workflows/tasks/bowtie.wdl
+++ b/workflows/tasks/bowtie.wdl
@@ -9,8 +9,8 @@ task bowtie {
         String? prefix
         String outputfile = if (defined(prefix)) then select_first([prefix,basename(fastqfile)]) + '.sam' else if (defined(fastqfile_R2)) then sub(basename(fastqfile),'_R?[12]_....f.*q.gz|_R?[12].f.*q.gz','.sam') else sub(basename(fastqfile),'.fastq.gz|.fq.gz','.sam')
         
-        Int? read_length = 75
-        Int? insert_size = 600
+        Int read_length = 75
+        Int insert_size = 600
         Int limit_alignments = 2
         Int good_alignments = 2
         Boolean best_alignments = true

--- a/workflows/tasks/bowtie.wdl
+++ b/workflows/tasks/bowtie.wdl
@@ -14,7 +14,7 @@ task bowtie {
         Int limit_alignments = 2
         Int good_alignments = 2
         Boolean best_alignments = true
-        String? strandedness = 'fr'
+        String strandedness = 'fr'
         String stranded_m = if strandedness=='fr' then '--fr'
                         else if strandedness=='rf' then '--rf'
                         else if strandedness=='ff' then '--ff'


### PR DESCRIPTION
Some WDL implementations (such as `miniwdl`) flag the use of an optional type (e.g. `String?`) in an equality check as an invalid type conversion. This seems to deviate from the spec. However in this case, `strandedness` has a default value specified. So there shouldn't be any need to make it optional as well. This just makes it a required parameter to alleviate errors when running with `miniwdl`. It shouldn't have any effect on the workflow itself.